### PR TITLE
version up dependent libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,46 +7,52 @@ val scalacOpts =
   Nil
 
 
-val scalikejdbcVersion = "2.2.+"
+val scalaVersion_ = "2.11.8"
+val scalikejdbcVersion = "2.3.+"
+val scalazVersion = "7.1.7"
+val scalatestVersion = "2.2.6"
+val scalacheckVersion = "1.12.1"
+val h2Version = "1.4.+"
+val kindProjectorVersion = "0.8.0"
 
 lazy val core = (project in file("core")).settings(
   name := """free-scalikejdbc""",
   version := "1.0",
-  scalaVersion := "2.11.6",
+  scalaVersion := scalaVersion_,
   resolvers += "bintray/non" at "http://dl.bintray.com/non/maven",
   resolvers += "Scalaz Bintray Repo" at "https://dl.bintray.com/scalaz/releases",
   libraryDependencies ++=
     ("org.scalikejdbc"         %% "scalikejdbc"                      % scalikejdbcVersion) ::
-    ("org.scalaz"              %% "scalaz-core"                      % "7.1.3") ::
-    ("org.scalaz"              %% "scalaz-concurrent"                % "7.1.3") ::
+    ("org.scalaz"              %% "scalaz-core"                      % scalazVersion) ::
+    ("org.scalaz"              %% "scalaz-concurrent"                % scalazVersion) ::
     ("org.scalaz.stream"       %% "scalaz-stream"                    % "0.7.1a") ::
-    ("com.h2database"           % "h2"                               % "1.4.+"              % "test") ::
+    ("com.h2database"           % "h2"                               % h2Version            % "test") ::
     ("org.scalikejdbc"         %% "scalikejdbc-test"                 % scalikejdbcVersion   % "test") ::
     ("org.scalikejdbc"         %% "scalikejdbc-config"               % scalikejdbcVersion   % "test") ::
     ("org.scalikejdbc"         %% "scalikejdbc-syntax-support-macro" % scalikejdbcVersion   % "test") ::
-    ("org.scalatest"           %% "scalatest"                        % "2.2.2"              % "test") ::
-    ("org.scalacheck"          %% "scalacheck"                       % "1.12.1"             % "test") ::
+    ("org.scalatest"           %% "scalatest"                        % scalatestVersion     % "test") ::
+    ("org.scalacheck"          %% "scalacheck"                       % scalacheckVersion    % "test") ::
     Nil,
   scalacOptions ++= scalacOpts,
   parallelExecution in Test := false,
-  addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.5.2")
+  addCompilerPlugin("org.spire-math" %% "kind-projector" % kindProjectorVersion)
 )
 
 lazy val sample = (project in file("sample")).settings(
   name := """free-scalikejdbc-sample""",
   version := "1.0",
-  scalaVersion := "2.11.6",
+  scalaVersion := scalaVersion_,
   resolvers ++= ("bintray/non" at "http://dl.bintray.com/non/maven") :: Resolver.sonatypeRepo("releases") :: Nil,
   libraryDependencies ++=
     ("org.scalikejdbc"         %% "scalikejdbc-config"               % scalikejdbcVersion) ::
     ("org.scalikejdbc"         %% "scalikejdbc-syntax-support-macro" % scalikejdbcVersion) ::
-    ("com.h2database"           % "h2"                               % "1.4.+") ::
-    ("org.scalatest"           %% "scalatest"                        % "2.2.2"              % "test") ::
-    ("org.scalacheck"          %% "scalacheck"                       % "1.12.1"             % "test") ::
+    ("com.h2database"           % "h2"                               % h2Version) ::
+    ("org.scalatest"           %% "scalatest"                        % scalatestVersion              % "test") ::
+    ("org.scalacheck"          %% "scalacheck"                       % scalacheckVersion             % "test") ::
     Nil,
   scalacOptions ++= scalacOpts,
-  addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.5.2"),
-  addCompilerPlugin("org.scalamacros" %% "paradise" % "2.0.1" cross CrossVersion.full)
+  addCompilerPlugin("org.spire-math" %% "kind-projector" % kindProjectorVersion),
+  addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full)
 ).dependsOn(core)
 
 lazy val root = (project in file(".")).aggregate(core, sample)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Fri Feb 06 13:25:23 JST 2015
 template.uuid=a855816c-0367-44ba-9adb-6a903f6ad599
-sbt.version=0.13.8
+sbt.version=0.13.12


### PR DESCRIPTION
change to latest version except scalacheck.
scalacheck latest is 1.13.1, but current tests are failed when updated, so I didn't.
