### PR TITLE
Update scalaz version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ScalikeJDBC **Composable** DSL by Free Monad  [![Build Status](https://travis-ci.org/gakuzzzz/free-scalikejdbc.svg?branch=feature%2Ftest)](https://travis-ci.org/gakuzzzz/free-scalikejdbc)
 
 ```scala
-  def createProgrammer[F[_]](name: Name, skillIds: List[SkillId])(implicit S: ScalikeJDBC[F], M: Applicative[FreeC[F, ?]]) = {
+  def createProgrammer[F[_]](name: Name, skillIds: List[SkillId])(implicit S: ScalikeJDBC[F], M: Applicative[Free[F, ?]]) = {
     import S._
     for {
       id     <- generateKey(insert.into(Programmer).namedValues(pc.name -> name))
       skills <- list(select.from(Skill as s).where.in(s.id, skillIds))(Skill(s))
-      _      <- skills.traverse[FreeC[F, ?], Boolean](s => execute(insert.into(ProgrammerSkill).namedValues(sc.programmerId -> id, sc.skillId -> s.id)))
+      _      <- skills.traverse[Free[F, ?], Boolean](s => execute(insert.into(ProgrammerSkill).namedValues(sc.programmerId -> id, sc.skillId -> s.id)))
     } yield Programmer(id, name, skills)
   }
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,8 @@ val scalacOpts =
 
 val scalaVersion_ = "2.11.8"
 val scalikejdbcVersion = "2.3.+"
-val scalazVersion = "7.1.7"
+val scalazVersion = "7.2.5"
+val scalazStreamVersion = "0.8.4a"
 val scalatestVersion = "2.2.6"
 val scalacheckVersion = "1.12.1"
 val h2Version = "1.4.+"
@@ -25,7 +26,7 @@ lazy val core = (project in file("core")).settings(
     ("org.scalikejdbc"         %% "scalikejdbc"                      % scalikejdbcVersion) ::
     ("org.scalaz"              %% "scalaz-core"                      % scalazVersion) ::
     ("org.scalaz"              %% "scalaz-concurrent"                % scalazVersion) ::
-    ("org.scalaz.stream"       %% "scalaz-stream"                    % "0.7.1a") ::
+    ("org.scalaz.stream"       %% "scalaz-stream"                    % scalazStreamVersion) ::
     ("com.h2database"           % "h2"                               % h2Version            % "test") ::
     ("org.scalikejdbc"         %% "scalikejdbc-test"                 % scalikejdbcVersion   % "test") ::
     ("org.scalikejdbc"         %% "scalikejdbc-config"               % scalikejdbcVersion   % "test") ::

--- a/core/src/main/scala/scalikejdbc/free/Interpreter.scala
+++ b/core/src/main/scala/scalikejdbc/free/Interpreter.scala
@@ -6,14 +6,14 @@ import scalikejdbc._
 
 import scalaz._
 import scalaz.Id._
-import scalaz.Free._
+import scalaz.Free
 import scalikejdbc.free.Query._
 
 abstract class Interpreter[M[_]](implicit M: Monad[M]) extends (Query ~> M) {
 
   protected def exec[A](f: DBSession => A): M[A]
 
-  def apply[A](c: Query[A]): M[A] = c match {
+  override def apply[A](c: Query[A]): M[A] = c match {
     case GetVector(sql)     => exec(implicit s => sql.apply[Vector]())
     case GetList(sql)       => exec(implicit s => sql.apply())
     case GetOption(sql)     => exec(implicit s => sql.apply())
@@ -23,7 +23,7 @@ abstract class Interpreter[M[_]](implicit M: Monad[M]) extends (Query ~> M) {
     case GenerateKey(sql)   => exec(implicit s => sql.apply())
   }
 
-  def run[A](q: FreeC[Query, A]): M[A] = Free.runFC(q)(this)
+  def run[A](q: Free[Query, A]): M[A] = q.foldMap(this)
 
 }
 

--- a/core/src/main/scala/scalikejdbc/free/ScalikeJDBC.scala
+++ b/core/src/main/scala/scalikejdbc/free/ScalikeJDBC.scala
@@ -3,37 +3,36 @@ package scalikejdbc.free
 import scalikejdbc.free.Query._
 import scalikejdbc._
 
-import scalaz.Free.FreeC
 import scalaz.{Free, Inject}
 
 sealed class ScalikeJDBC[F[_]](implicit I: Inject[Query, F]) {
 
-  private def lift[A](v: Query[A]): FreeC[F, A] = Free.liftFC(I.inj(v))
+  private def lift[A](v: Query[A]): Free[F, A] = Free.liftF(I.inj(v))
 
-  def vector[A](sql: SQL[A, HasExtractor]): FreeC[F, Vector[A]] = lift(GetVector[A](sql.collection))
-  def vector[A](sql: SQLBuilder[_])(f: WrappedResultSet => A): FreeC[F, Vector[A]] = vector(withSQL(sql).map(f))
+  def vector[A](sql: SQL[A, HasExtractor]): Free[F, Vector[A]] = lift(GetVector[A](sql.collection))
+  def vector[A](sql: SQLBuilder[_])(f: WrappedResultSet => A): Free[F, Vector[A]] = vector(withSQL(sql).map(f))
 
-  def list[A](sql: SQL[A, HasExtractor]): FreeC[F, List[A]] = lift(GetList[A](sql.list()))
-  def list[A](sql: SQLBuilder[_])(f: WrappedResultSet => A): FreeC[F, List[A]] = list(withSQL(sql).map(f))
+  def list[A](sql: SQL[A, HasExtractor]): Free[F, List[A]] = lift(GetList[A](sql.list()))
+  def list[A](sql: SQLBuilder[_])(f: WrappedResultSet => A): Free[F, List[A]] = list(withSQL(sql).map(f))
 
-  def first[A](sql: SQL[A, HasExtractor]): FreeC[F, Option[A]] = lift(GetOption[A](sql.first()))
-  def first[A](sql: SQLBuilder[_])(f: WrappedResultSet => A): FreeC[F, Option[A]] = first(withSQL(sql).map(f))
+  def first[A](sql: SQL[A, HasExtractor]): Free[F, Option[A]] = lift(GetOption[A](sql.first()))
+  def first[A](sql: SQLBuilder[_])(f: WrappedResultSet => A): Free[F, Option[A]] = first(withSQL(sql).map(f))
 
-  def single[A](sql: SQL[A, HasExtractor]): FreeC[F, Option[A]] = lift(GetOption[A](sql.single()))
-  def single[A](sql: SQLBuilder[_])(f: WrappedResultSet => A): FreeC[F, Option[A]] = single(withSQL(sql).map(f))
+  def single[A](sql: SQL[A, HasExtractor]): Free[F, Option[A]] = lift(GetOption[A](sql.single()))
+  def single[A](sql: SQLBuilder[_])(f: WrappedResultSet => A): Free[F, Option[A]] = single(withSQL(sql).map(f))
 
-  def foldLeft[A](sql: SQL[_, NoExtractor])(init: A)(f: (A, WrappedResultSet) => A): FreeC[F, A] = lift(Fold(sql, init, f))
-  def foldLeft[A](sql: SQLBuilder[_])(init: A)(f: (A, WrappedResultSet) => A): FreeC[F, A] = foldLeft(withSQL(sql))(init)(f)
+  def foldLeft[A](sql: SQL[_, NoExtractor])(init: A)(f: (A, WrappedResultSet) => A): Free[F, A] = lift(Fold(sql, init, f))
+  def foldLeft[A](sql: SQLBuilder[_])(init: A)(f: (A, WrappedResultSet) => A): Free[F, A] = foldLeft(withSQL(sql))(init)(f)
 
 
-  def execute(sql: SQL[_, NoExtractor]): FreeC[F, Boolean] = lift(Execute(sql.execute()))
-  def execute(sql: SQLBuilder[UpdateOperation]): FreeC[F, Boolean] = execute(withSQL(sql))
+  def execute(sql: SQL[_, NoExtractor]): Free[F, Boolean] = lift(Execute(sql.execute()))
+  def execute(sql: SQLBuilder[UpdateOperation]): Free[F, Boolean] = execute(withSQL(sql))
 
-  def update(sql: SQL[_, NoExtractor]): FreeC[F, Int] = lift(Update(sql.update()))
-  def update(sql: SQLBuilder[UpdateOperation]): FreeC[F, Int] = update(withSQL(sql))
+  def update(sql: SQL[_, NoExtractor]): Free[F, Int] = lift(Update(sql.update()))
+  def update(sql: SQLBuilder[UpdateOperation]): Free[F, Int] = update(withSQL(sql))
 
-  def generateKey(sql: SQL[_, NoExtractor]): FreeC[F, Long] = lift(GenerateKey(sql.updateAndReturnGeneratedKey()))
-  def generateKey(sql: SQLBuilder[UpdateOperation]): FreeC[F, Long] = generateKey(withSQL(sql))
+  def generateKey(sql: SQL[_, NoExtractor]): Free[F, Long] = lift(GenerateKey(sql.updateAndReturnGeneratedKey()))
+  def generateKey(sql: SQLBuilder[UpdateOperation]): Free[F, Long] = generateKey(withSQL(sql))
 
 }
 


### PR DESCRIPTION
Hi, @gakuzzzz.

I've used free-scalikejdbc for my commercial products and want to update scalaz version for some reason. But scalaz doesn't provide `FreeC` type anymore from `7.2`. So I fixed the code to make all unit tests green.

I updated the scalaz version to the latest and is it OK for you?

See this commit for more detail:
https://github.com/scalaz/scalaz/commit/783eb0ed7f6aec56d6245e9b2b9bac97aab74d22.

Sincerely.
